### PR TITLE
Replace NotificationLite usage for RxJava 1.2.1 change

### DIFF
--- a/src/main/java/com/jakewharton/rxrelay/NotificationLite.java
+++ b/src/main/java/com/jakewharton/rxrelay/NotificationLite.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jakewharton.rxrelay;
+
+import java.io.Serializable;
+
+import rx.Notification.Kind;
+import rx.Observer;
+
+/**
+ * For use in internal operators that need something like materialize and dematerialize wholly within the
+ * implementation of the operator but don't want to incur the allocation cost of actually creating
+ * {@link rx.Notification} objects for every {@link Observer#onNext onNext} and
+ * {@link Observer#onCompleted onCompleted}.
+ * <p>
+ * An object is allocated inside {@link #error(Throwable)} to wrap the {@link Throwable} but this shouldn't
+ * affect performance because exceptions should be exceptionally rare.
+ * <p>
+ * It's implemented as a singleton to maintain some semblance of type safety that is completely non-existent.
+ *
+ * @param <T> the element type
+ */
+final class NotificationLite<T> {
+
+    private NotificationLite() {
+        // singleton
+    }
+
+    private static final Object ON_COMPLETED_SENTINEL = new Serializable() {
+        private static final long serialVersionUID = 1;
+
+        @Override
+        public String toString() {
+            return "Notification=>Completed";
+        }
+    };
+
+    private static final Object ON_NEXT_NULL_SENTINEL = new Serializable() {
+        private static final long serialVersionUID = 2;
+
+        @Override
+        public String toString() {
+            return "Notification=>NULL";
+        }
+    };
+
+    static final class OnErrorSentinel implements Serializable {
+        private static final long serialVersionUID = 3;
+        final Throwable e;
+
+        public OnErrorSentinel(Throwable e) {
+            this.e = e;
+        }
+
+        @Override
+        public String toString() {
+            return "Notification=>Error:" + e;
+        }
+    }
+
+    /**
+     * Creates a lite {@code onNext} notification for the value passed in without doing any allocation. Can
+     * be unwrapped and sent with the {@link #accept} method.
+     *
+     * @param <T> the value type to convert
+     * @param t
+     *          the item emitted to {@code onNext}
+     * @return the item, or a null token representing the item if the item is {@code null}
+     */
+    public static <T> Object next(T t) {
+        if (t == null) {
+            return ON_NEXT_NULL_SENTINEL;
+        } else {
+            return t;
+        }
+    }
+
+    /**
+     * Creates a lite {@code onCompleted} notification without doing any allocation. Can be unwrapped and
+     * sent with the {@link #accept} method.
+     *
+     * @return a completion token
+     */
+    public static Object completed() {
+        return ON_COMPLETED_SENTINEL;
+    }
+
+    /**
+     * Create a lite {@code onError} notification. This call creates an object to wrap the {@link Throwable},
+     * but since there should only be one of these, the performance impact should be small. Can be unwrapped and
+     * sent with the {@link #accept} method.
+     *
+     * @param e
+     *           the {@code Throwable} in the {@code onError} notification
+     * @return an object encapsulating the exception
+     */
+    public static Object error(Throwable e) {
+        return new OnErrorSentinel(e);
+    }
+
+    /**
+     * Unwraps the lite notification and calls the appropriate method on the {@link Observer}.
+     *
+     * @param <T> the value type to accept
+     * @param o
+     *            the {@link Observer} to call {@code onNext}, {@code onCompleted}, or {@code onError}.
+     * @param n
+     *            the lite notification
+     * @return {@code true} if {@code n} represents a termination event; {@code false} otherwise
+     * @throws IllegalArgumentException
+     *             if the notification is null.
+     * @throws NullPointerException
+     *             if the {@link Observer} is null.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> boolean accept(Observer<? super T> o, Object n) {
+        if (n == ON_COMPLETED_SENTINEL) {
+            o.onCompleted();
+            return true;
+        } else if (n == ON_NEXT_NULL_SENTINEL) {
+            o.onNext(null);
+            return false;
+        } else if (n != null) {
+            if (n.getClass() == OnErrorSentinel.class) {
+                o.onError(((OnErrorSentinel) n).e);
+                return true;
+            }
+            o.onNext((T) n);
+            return false;
+        } else {
+            throw new IllegalArgumentException("The lite notification can not be null");
+        }
+    }
+
+    /**
+     * Indicates whether or not the lite notification represents an {@code onCompleted} event.
+     *
+     * @param n
+     *            the lite notification
+     * @return {@code true} if {@code n} represents an {@code onCompleted} event; {@code false} otherwise
+     */
+    public static boolean isCompleted(Object n) {
+        return n == ON_COMPLETED_SENTINEL;
+    }
+
+    /**
+     * Indicates whether or not the lite notification represents an {@code onError} event.
+     *
+     * @param n
+     *            the lite notification
+     * @return {@code true} if {@code n} represents an {@code onError} event; {@code false} otherwise
+     */
+    public static boolean isError(Object n) {
+        return n instanceof OnErrorSentinel;
+    }
+
+    /**
+     * Indicates whether or not the lite notification represents a wrapped {@code null} {@code onNext} event.
+     * @param n the lite notification
+     * @return {@code true} if {@code n} represents a wrapped {@code null} {@code onNext} event, {@code false} otherwise
+     */
+    public static boolean isNull(Object n) {
+        return n == ON_NEXT_NULL_SENTINEL;
+    }
+
+    /**
+     * Indicates whether or not the lite notification represents an {@code onNext} event.
+     * @param n the lite notification
+     * @return {@code true} if {@code n} represents an {@code onNext} event, {@code false} otherwise
+     */
+    public static boolean isNext(Object n) {
+        return n != null && !isError(n) && !isCompleted(n);
+    }
+
+    /**
+     * Indicates which variety a particular lite notification is. If you need something more complex than
+     * simply calling the right method on an {@link Observer} then you can use this method to get the
+     * {@link rx.Notification.Kind}.
+     *
+     * @param n
+     *            the lite notification
+     * @throws IllegalArgumentException
+     *             if the notification is null.
+     * @return the {@link Kind} of lite notification {@code n} is: either {@code Kind.OnCompleted},
+     *         {@code Kind.OnError}, or {@code Kind.OnNext}
+     */
+    public static Kind kind(Object n) {
+        if (n == null) {
+            throw new IllegalArgumentException("The lite notification can not be null");
+        } else if (n == ON_COMPLETED_SENTINEL) {
+            return Kind.OnCompleted;
+        } else if (n instanceof OnErrorSentinel) {
+            return Kind.OnError;
+        } else {
+            // value or ON_NEXT_NULL_SENTINEL but either way it's an OnNext
+            return Kind.OnNext;
+        }
+    }
+
+    /**
+     * Returns the item corresponding to this {@code OnNext} lite notification. Bad things happen if you pass
+     * this an {@code OnComplete} or {@code OnError} notification type. For performance reasons, this method
+     * does not check for this, so you are expected to prevent such a mishap.
+     *
+     * @param <T> the value type to convert
+     * @param n
+     *            the lite notification (of type {@code Kind.OnNext})
+     * @return the unwrapped value, which can be null
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T getValue(Object n) {
+        return n == ON_NEXT_NULL_SENTINEL ? null : (T) n;
+    }
+
+    /**
+     * Returns the {@link Throwable} corresponding to this {@code OnError} lite notification. Bad things happen
+     * if you pass this an {@code OnComplete} or {@code OnNext} notification type. For performance reasons, this
+     * method does not check for this, so you are expected to prevent such a mishap.
+     *
+     * @param n
+     *            the lite notification (of type {@code Kind.OnError})
+     * @return the {@link Throwable} wrapped inside {@code n}
+     */
+    public static Throwable getError(Object n) {
+        return ((OnErrorSentinel) n).e;
+    }
+}

--- a/src/main/java/com/jakewharton/rxrelay/RelaySubscriptionManager.java
+++ b/src/main/java/com/jakewharton/rxrelay/RelaySubscriptionManager.java
@@ -25,7 +25,6 @@ import rx.Subscriber;
 import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.functions.Actions;
-import rx.internal.operators.NotificationLite;
 import rx.subscriptions.Subscriptions;
 
 /**
@@ -44,8 +43,6 @@ import rx.subscriptions.Subscriptions;
   Action1<RelayObserver<T>> onStart = Actions.empty();
   /** Action called after the subscriber has been added to the state. */
   Action1<RelayObserver<T>> onAdded = Actions.empty();
-  /** The notification lite. */
-  final NotificationLite<T> nl = NotificationLite.instance();
 
   RelaySubscriptionManager() {
     super(State.EMPTY);
@@ -221,9 +218,8 @@ import rx.subscriptions.Subscriptions;
      * prevents the emitFirst to run if not already run.
      *
      * @param n the NotificationLite value
-     * @param nl the type-appropriate notification lite object
      */
-    void emitNext(Object n, final NotificationLite<T> nl) {
+    void emitNext(Object n) {
       if (!fastPath) {
         synchronized (this) {
           first = false;
@@ -237,7 +233,7 @@ import rx.subscriptions.Subscriptions;
         }
         fastPath = true;
       }
-      nl.accept(actual, n);
+      NotificationLite.accept(actual, n);
     }
 
     /**
@@ -245,9 +241,8 @@ import rx.subscriptions.Subscriptions;
      * value and drains the queue as long as possible.
      *
      * @param n the NotificationLite value
-     * @param nl the type-appropriate notification lite object
      */
-    void emitFirst(Object n, final NotificationLite<T> nl) {
+    void emitFirst(Object n) {
       synchronized (this) {
         if (!first || emitting) {
           return;
@@ -256,7 +251,7 @@ import rx.subscriptions.Subscriptions;
         emitting = n != null;
       }
       if (n != null) {
-        emitLoop(null, n, nl);
+        emitLoop(null, n);
       }
     }
 
@@ -265,21 +260,20 @@ import rx.subscriptions.Subscriptions;
      *
      * @param localQueue the initial queue contents
      * @param current the current content to emit
-     * @param nl the type-appropriate notification lite object
      */
-    private void emitLoop(List<Object> localQueue, Object current, final NotificationLite<T> nl) {
+    private void emitLoop(List<Object> localQueue, Object current) {
       boolean once = true;
       boolean skipFinal = false;
       try {
         do {
           if (localQueue != null) {
             for (Object n : localQueue) {
-              accept(n, nl);
+              accept(n);
             }
           }
           if (once) {
             once = false;
-            accept(current, nl);
+            accept(current);
           }
           synchronized (this) {
             localQueue = queue;
@@ -304,11 +298,10 @@ import rx.subscriptions.Subscriptions;
      * Dispatches a NotificationLite value to the actual Observer.
      *
      * @param n the value to dispatch
-     * @param nl the type-appropriate notification lite object
      */
-    private void accept(Object n, final NotificationLite<T> nl) {
+    private void accept(Object n) {
       if (n != null) {
-        nl.accept(actual, n);
+        NotificationLite.accept(actual, n);
       }
     }
 

--- a/src/main/java/com/jakewharton/rxrelay/TestRelay.java
+++ b/src/main/java/com/jakewharton/rxrelay/TestRelay.java
@@ -36,7 +36,7 @@ public final class TestRelay<T> extends Relay<T, T> {
 
     state.onAdded = new Action1<RelayObserver<T>>() {
       @Override public void call(RelayObserver<T> o) {
-        o.emitFirst(state.getLatest(), state.nl);
+        o.emitFirst(state.getLatest());
       }
     };
 

--- a/src/test/java/com/jakewharton/rxrelay/NotificationLiteTest.java
+++ b/src/test/java/com/jakewharton/rxrelay/NotificationLiteTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jakewharton.rxrelay;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+
+public class NotificationLiteTest {
+
+    @Test
+    public void testComplete() {
+        Object n = NotificationLite.next("Hello");
+        Object c = NotificationLite.completed();
+
+        assertTrue(NotificationLite.isCompleted(c));
+        assertFalse(NotificationLite.isCompleted(n));
+
+        assertEquals("Hello", NotificationLite.getValue(n));
+    }
+
+    @Test
+    public void testValueKind() {
+
+        assertTrue(NotificationLite.isNull(NotificationLite.next(null)));
+        assertFalse(NotificationLite.isNull(NotificationLite.next(1)));
+        assertFalse(NotificationLite.isNull(NotificationLite.error(new RuntimeException())));
+        assertFalse(NotificationLite.isNull(NotificationLite.completed()));
+        assertFalse(NotificationLite.isNull(null));
+
+        assertTrue(NotificationLite.isNext(NotificationLite.next(null)));
+        assertTrue(NotificationLite.isNext(NotificationLite.next(1)));
+        assertFalse(NotificationLite.isNext(NotificationLite.completed()));
+        assertFalse(NotificationLite.isNext(null));
+        assertFalse(NotificationLite.isNext(NotificationLite.error(new RuntimeException())));
+    }
+}


### PR DESCRIPTION
Fixes #13.

RxJava 1.2.1 changes in https://github.com/ReactiveX/RxJava/pull/4621 broke the usage of RxJava `rx.internal.operators.NotificationLite`. The singleton `NotificationLite` instance was removed and the methods on it are now static methods on the `NotificationLite` class. This pull request changes all usages of the `NotificationLite` instance methods to use the static methods.

This is the simplest fix for supporting RxJava 1.2.1, but note this will break RxRelay when used with RxJava <= 1.2.0. If this is unacceptable then some sort of shim could be added.
