### PR TITLE
Changed comment to reflect logic of add(..) method

### DIFF
--- a/src/main/java/com/jakewharton/rxrelay2/PublishRelay.java
+++ b/src/main/java/com/jakewharton/rxrelay2/PublishRelay.java
@@ -75,8 +75,7 @@ public final class PublishRelay<T> extends Relay<T> {
     }
 
     /**
-     * Tries to add the given subscriber to the subscribers array atomically
-     * or returns false if the subject has terminated.
+     * Adds the given subscriber to the subscribers array atomically.
      * @param ps the subscriber to add
      */
     private void add(PublishDisposable<T> ps) {


### PR DESCRIPTION
It looks like this method used to return a boolean if it failed to add a subscriber to the array. In the latest version, the add(..) method will keep looping until it successfully adds the subscriber.