### PR TITLE
Added nullability annotation to Behavior and Replay relay

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
-      <version>2.0.1</version>
+      <version>2.1.10</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/jakewharton/rxrelay2/BehaviorRelay.java
+++ b/src/main/java/com/jakewharton/rxrelay2/BehaviorRelay.java
@@ -15,6 +15,7 @@ package com.jakewharton.rxrelay2;
 
 import com.jakewharton.rxrelay2.AppendOnlyLinkedArrayList.NonThrowingPredicate;
 import io.reactivex.Observer;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.disposables.Disposable;
 import java.lang.reflect.Array;
 import java.util.concurrent.atomic.AtomicReference;
@@ -141,6 +142,7 @@ public final class BehaviorRelay<T> extends Relay<T> {
      * Returns a single value the Relay currently has or null if no such value exists.
      * <p>The method is thread-safe.
      */
+    @Nullable
     public T getValue() {
         return value.get();
     }

--- a/src/main/java/com/jakewharton/rxrelay2/ReplayRelay.java
+++ b/src/main/java/com/jakewharton/rxrelay2/ReplayRelay.java
@@ -15,6 +15,7 @@ package com.jakewharton.rxrelay2;
 
 import io.reactivex.Observer;
 import io.reactivex.Scheduler;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.disposables.Disposable;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -234,6 +235,7 @@ public final class ReplayRelay<T> extends Relay<T> {
      * Returns a single value the Relay currently has or null if no such value exists.
      * <p>The method is thread-safe.
      */
+    @Nullable
     public T getValue() {
         return buffer.getValue();
     }
@@ -338,6 +340,7 @@ public final class ReplayRelay<T> extends Relay<T> {
 
         int size();
 
+        @Nullable
         T getValue();
 
         T[] getValues(T[] array);
@@ -394,6 +397,7 @@ public final class ReplayRelay<T> extends Relay<T> {
         }
 
         @Override
+        @Nullable
         @SuppressWarnings("unchecked")
         public T getValue() {
             int s = size;
@@ -558,6 +562,7 @@ public final class ReplayRelay<T> extends Relay<T> {
         }
 
         @Override
+        @Nullable
         @SuppressWarnings("unchecked")
         public T getValue() {
             Node<T> h = head;
@@ -743,6 +748,7 @@ public final class ReplayRelay<T> extends Relay<T> {
         }
 
         @Override
+        @Nullable
         @SuppressWarnings("unchecked")
         public T getValue() {
             TimedNode<T> h = head;

--- a/src/test/java/com/jakewharton/rxrelay2/BehaviorRelayTest.java
+++ b/src/test/java/com/jakewharton/rxrelay2/BehaviorRelayTest.java
@@ -263,6 +263,7 @@ public class BehaviorRelayTest {
 
             Runnable r1 = new Runnable() {
                 @Override
+                @SuppressWarnings("CheckReturnValue")
                 public void run() {
                     p.test();
                 }

--- a/src/test/java/com/jakewharton/rxrelay2/PublishRelayTest.java
+++ b/src/test/java/com/jakewharton/rxrelay2/PublishRelayTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.verify;
 public class PublishRelayTest {
 
     @Test
+    @SuppressWarnings("CheckReturnValue")
     public void testNestedSubscribe() {
         final PublishRelay<Integer> s = PublishRelay.create();
 
@@ -271,6 +272,7 @@ public class PublishRelayTest {
     }
 
     @Test
+    @SuppressWarnings("CheckReturnValue")
     public void subscribedTo() {
         PublishRelay<Integer> pp = PublishRelay.create();
         PublishRelay<Integer> pp2 = PublishRelay.create();

--- a/src/test/java/com/jakewharton/rxrelay2/ReplayRelayTest.java
+++ b/src/test/java/com/jakewharton/rxrelay2/ReplayRelayTest.java
@@ -362,6 +362,7 @@ public class ReplayRelayTest {
 
             Runnable r1 = new Runnable() {
                 @Override
+                @SuppressWarnings("CheckReturnValue")
                 public void run() {
                     rp.test();
                 }
@@ -372,6 +373,7 @@ public class ReplayRelayTest {
     }
 
     @Test
+    @SuppressWarnings("CheckReturnValue")
     public void cancelUpfront() {
         ReplayRelay<Integer> rp = ReplayRelay.create();
         rp.test();


### PR DESCRIPTION
Fixes - https://github.com/JakeWharton/RxRelay/issues/36
Added nullability annotations to Behavior and Replay relay getValue methods. It also needs a bump in RxJava for annotations. 

There are no nullable annotations except JDK internals. Should we use some other annotations to avoid the bump in Rx?